### PR TITLE
feat(claude): add Gleam auto-rebuild hook, sync skill, and protocol analyzer

### DIFF
--- a/.claude/agents/protocol-analyzer.md
+++ b/.claude/agents/protocol-analyzer.md
@@ -1,0 +1,102 @@
+---
+name: protocol-analyzer
+description: Analyze Gleam protocol changes for correctness and Elixir compatibility
+tools: Read, Grep, Glob
+---
+
+# Protocol Analyzer
+
+Specialized agent for reviewing Gleam protocol changes in `levee_protocol/src/` for correctness and Elixir interoperability.
+
+## When to Invoke
+
+- After modifying Gleam protocol types or functions
+- When adding new message types or signals
+- Before merging protocol changes
+- When debugging Elixir↔Gleam type mismatches
+
+## Analysis Checklist
+
+### 1. Type Safety
+
+Check that all Gleam types have proper Elixir handling:
+
+| Gleam Type | Elixir Pattern | Verify |
+|------------|----------------|--------|
+| `Result(ok, err)` | `{:ok, val}` / `{:error, val}` | Pattern match both cases |
+| `Option(a)` | `nil` / value | Nil checks present |
+| `Dict(k, v)` | `%{}` map | Key types compatible |
+| `List(a)` | `[]` list | Element types consistent |
+
+### 2. Key File Cross-References
+
+When a Gleam file changes, verify corresponding Elixir code:
+
+| Gleam File | Elixir Consumers |
+|------------|------------------|
+| `types.gleam` | `lib/levee/protocol/bridge.ex` |
+| `sequencing.gleam` | `lib/levee/documents/session.ex` |
+| `message.gleam` | `lib/levee_web/channels/document_channel.ex` |
+| `signal.gleam` | `lib/levee_web/channels/document_channel.ex` |
+| `validation.gleam` | `lib/levee/protocol/bridge.ex` |
+| `nack.gleam` | `lib/levee_web/channels/document_channel.ex` |
+| `jwt.gleam` | `lib/levee/auth/jwt.ex` |
+
+### 3. Sequencing Rules
+
+For changes to `sequencing.gleam`:
+
+- [ ] ref_seq validation logic is correct
+- [ ] seq_num assignment is monotonic
+- [ ] State transitions are valid
+- [ ] Error cases return appropriate NACKs
+
+### 4. Broadcast Ordering
+
+For changes affecting message flow:
+
+- [ ] Operations are sequenced before broadcast
+- [ ] Signals bypass sequencing appropriately
+- [ ] Client acknowledgments handled
+
+### 5. Public API Surface
+
+For changes to `levee_protocol.gleam`:
+
+- [ ] New public functions documented
+- [ ] Exports match intended API
+- [ ] Backward compatibility maintained (or breaking change noted)
+
+## Module Naming Reference
+
+Gleam modules compile to Erlang atoms:
+
+```
+levee_protocol.gleam      → :levee_protocol
+sequencing.gleam          → :levee_protocol@sequencing
+message.gleam             → :levee_protocol@message
+```
+
+## Verification Commands
+
+```bash
+# Type check Gleam
+cd levee_protocol && gleam check
+
+# Run Gleam tests
+cd levee_protocol && gleam test
+
+# Run Elixir integration tests
+mix test test/levee/protocol/ test/levee/documents/
+
+# Full test suite
+just test
+```
+
+## Common Issues to Flag
+
+1. **Unhandled Result cases** - Elixir code only matches `{:ok, _}` but not `{:error, _}`
+2. **Option/nil confusion** - Gleam `None` becomes `nil`, not `:none`
+3. **Atom casing** - Gleam uses lowercase atoms, ensure Elixir matches
+4. **Missing recompile** - Changes not visible until `mix compile --force`
+5. **Dict key types** - Gleam string keys vs Elixir atom keys

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *.gleam) cd levee_protocol && gleam build --target erlang 2>&1 | head -10; break;; esac; done"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/gleam-sync/SKILL.md
+++ b/.claude/skills/gleam-sync/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: gleam-sync
+description: Rebuild Gleam protocol and reload Elixir modules
+---
+
+# Gleam Sync
+
+Synchronize Gleam protocol changes with Elixir after modifying files in `levee_protocol/src/`.
+
+## Quick Sync
+
+```bash
+cd levee_protocol && gleam build --target erlang && cd .. && mix compile --force
+```
+
+## Full Verification
+
+After sync, verify the changes:
+
+```bash
+# Run Gleam tests
+cd levee_protocol && gleam test
+
+# Run Elixir tests that use the protocol
+mix test test/levee/protocol/ test/levee/documents/
+```
+
+## When to Use
+
+- After modifying any `.gleam` file in `levee_protocol/src/`
+- After adding new Gleam dependencies
+- When Elixir code reports "undefined function" for Gleam modules
+- After `git pull` that includes Gleam changes
+
+## Troubleshooting
+
+If Elixir doesn't see Gleam changes:
+
+```bash
+# Clean rebuild
+cd levee_protocol && gleam clean && gleam build --target erlang
+cd .. && mix compile --force
+```
+
+If module not found errors persist:
+
+```bash
+# Check BEAM files exist
+ls levee_protocol/build/dev/erlang/levee_protocol/ebin/*.beam
+```


### PR DESCRIPTION
## Summary

- Add PostToolUse hook that automatically rebuilds Gleam protocol when `.gleam` files are edited
- Add `gleam-sync` skill for manual sync workflow (`/gleam-sync`)
- Add `protocol-analyzer` agent for reviewing Gleam↔Elixir interop changes
