### PR TITLE
fix(driver): use relative path for delta storage URL

### DIFF
--- a/client/packages/levee-driver/src/leveeDocumentServiceFactory.ts
+++ b/client/packages/levee-driver/src/leveeDocumentServiceFactory.ts
@@ -152,7 +152,7 @@ export class LeveeDocumentServiceFactory implements IDocumentServiceFactory {
 			documentId: documentId,
 			url: `${leveeUrl.httpUrl}/${leveeUrl.tenantId}/${documentId}`,
 			endpoints: {
-				deltaStorageUrl: `${leveeUrl.httpUrl}/deltas/${leveeUrl.tenantId}/${documentId}`,
+				deltaStorageUrl: `/deltas/${leveeUrl.tenantId}/${documentId}`,
 				storageUrl: `${leveeUrl.httpUrl}/repos/${leveeUrl.tenantId}`,
 			},
 		};

--- a/client/packages/levee-driver/src/urlResolver.ts
+++ b/client/packages/levee-driver/src/urlResolver.ts
@@ -79,7 +79,7 @@ export class LeveeUrlResolver implements IUrlResolver {
 			socketUrl: this.socketUrl,
 			httpUrl: this.httpUrl,
 			endpoints: {
-				deltaStorageUrl: `${this.httpUrl}/deltas/${tenantId}/${documentId}`,
+				deltaStorageUrl: `/deltas/${tenantId}/${documentId}`,
 				storageUrl: `${this.httpUrl}/repos/${tenantId}`,
 			},
 			tokens: {},


### PR DESCRIPTION
## Summary

- Fix double URL bug in delta storage requests where deltaStorageUrl was set to a full absolute URL (e.g., http://localhost:4000/deltas/fluid/docId) but RestWrapper.get() prepends the base URL, resulting in http://localhost:4000/http://localhost:4000/deltas/fluid/docId and 404 errors
- Changed deltaStorageUrl to a relative path (/deltas/...) in both urlResolver.ts and leveeDocumentServiceFactory.ts so RestWrapper correctly constructs the full URL

## Test plan

- [x] pnpm build compiles successfully
- [x] pnpm format passes with no changes
- [ ] Manual verification: start server and client, confirm delta storage requests hit the correct URL without doubling