### PR TITLE
feat(client): add todo-list example and presence-tracker disconnect tests

### DIFF
--- a/client/packages/levee-presence-tracker/e2e/presence-tracker.spec.ts
+++ b/client/packages/levee-presence-tracker/e2e/presence-tracker.spec.ts
@@ -190,4 +190,45 @@ test.describe("multi-user presence sync", () => {
 		expect(reactionText).toBeTruthy();
 		expect(reactionText!.length).toBeGreaterThan(0);
 	});
+
+	test("second user disconnects - first user sees attendee leave", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// Wait for both users to see 2 users
+		await waitForPresenceCount(page1, 2);
+		await waitForPresenceCount(page2, 2);
+
+		// Disconnect page2 by navigating away
+		await page2.goto("about:blank");
+
+		// Page1 should eventually see only 1 user in the focus panel
+		await waitForPresenceCount(page1, 1);
+	});
+
+	test("disconnected user can rejoin", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// Wait for both users to see 2 users
+		await waitForPresenceCount(page1, 2);
+		await waitForPresenceCount(page2, 2);
+
+		// Get the container URL before disconnecting
+		const containerUrl = page1.url();
+
+		// Disconnect page2
+		await page2.goto("about:blank");
+
+		// Wait for page1 to see only 1 user
+		await waitForPresenceCount(page1, 1);
+
+		// Reconnect page2 to the same container
+		await page2.goto(containerUrl);
+		await waitForConnected(page2);
+
+		// Both should see 2 users again
+		await waitForPresenceCount(page1, 2);
+		await waitForPresenceCount(page2, 2);
+	});
 });

--- a/client/packages/levee-todo-list/e2e/fixtures/test-fixtures.ts
+++ b/client/packages/levee-todo-list/e2e/fixtures/test-fixtures.ts
@@ -1,0 +1,106 @@
+import {
+	type BrowserContext,
+	test as base,
+	expect,
+	type Page,
+} from "@playwright/test";
+
+const CONNECTION_TIMEOUT = 15_000;
+
+export interface TestFixtures {
+	connectedPage: Page;
+	secondUser: {
+		context: BrowserContext;
+		page: Page;
+	};
+}
+
+/**
+ * Wait for the page to show "connected" status
+ */
+export async function waitForConnected(page: Page): Promise<void> {
+	await expect(page.locator("#status")).toContainText("Connected:", {
+		timeout: CONNECTION_TIMEOUT,
+	});
+}
+
+/**
+ * Wait for the todo-list view to be fully loaded
+ */
+export async function waitForTodoView(page: Page): Promise<void> {
+	await expect(page.locator(".todo-view")).toBeVisible({
+		timeout: CONNECTION_TIMEOUT,
+	});
+}
+
+/**
+ * Extract the container ID from the URL hash
+ */
+export function getContainerIdFromUrl(page: Page): string {
+	const hash = new URL(page.url()).hash;
+	return hash.replace("#", "");
+}
+
+/**
+ * Attach console logging from a browser page to Node.js stdout for debugging.
+ */
+function attachConsoleLogger(page: Page, label: string): void {
+	page.on("console", (msg) => {
+		const type = msg.type();
+		if (type === "error" || type === "warning" || type === "info") {
+			// biome-ignore lint/suspicious/noConsole: e2e debugging
+			console.log(`[${label}:${type}] ${msg.text()}`);
+		}
+	});
+}
+
+export const test = base.extend<TestFixtures>({
+	/**
+	 * Provides a page that's already connected to a new container with the todo-list loaded.
+	 * Each test gets its own fresh container.
+	 */
+	connectedPage: async ({ page }, use) => {
+		attachConsoleLogger(page, "user1");
+
+		// Navigate to create a new container
+		await page.goto("/");
+
+		// Wait for connection and todo view to load
+		await waitForConnected(page);
+		await waitForTodoView(page);
+
+		// Verify container ID is in the URL
+		const containerId = getContainerIdFromUrl(page);
+		expect(containerId).toBeTruthy();
+
+		await use(page);
+	},
+
+	/**
+	 * Creates a second browser context with a unique user identity
+	 * that joins the same container as the first user.
+	 */
+	secondUser: async ({ browser, connectedPage }, use) => {
+		// Get the container URL from the first user's page
+		const containerUrl = connectedPage.url();
+
+		// Create a new browser context (simulates a different user/session)
+		const context = await browser.newContext();
+		const page = await context.newPage();
+		attachConsoleLogger(page, "user2");
+
+		// Navigate to the same container URL
+		await page.goto(containerUrl);
+
+		// Wait for the second user to connect and load
+		await waitForConnected(page);
+		await waitForTodoView(page);
+
+		await use({ context, page });
+
+		// Cleanup
+		await context.close();
+	},
+});
+
+export { expect };

--- a/client/packages/levee-todo-list/e2e/global-setup.ts
+++ b/client/packages/levee-todo-list/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { ensureServerRunning } from "./support/server-manager.ts";
+
+export default async function globalSetup(): Promise<void> {
+	await ensureServerRunning();
+}

--- a/client/packages/levee-todo-list/e2e/support/server-manager.ts
+++ b/client/packages/levee-todo-list/e2e/support/server-manager.ts
@@ -1,0 +1,63 @@
+import { exec } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LEVEE_CLIENT_DIR = join(__dirname, "../../../levee-client");
+const HEALTH_URL = "http://localhost:4000/health";
+const HEALTH_CHECK_TIMEOUT_MS = 30_000;
+const HEALTH_CHECK_INTERVAL_MS = 1_000;
+
+async function checkHealth(): Promise<boolean> {
+	try {
+		const response = await fetch(HEALTH_URL);
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForHealth(timeoutMs: number): Promise<void> {
+	const startTime = Date.now();
+
+	while (Date.now() - startTime < timeoutMs) {
+		if (await checkHealth()) {
+			return;
+		}
+		await new Promise((resolve) =>
+			setTimeout(resolve, HEALTH_CHECK_INTERVAL_MS),
+		);
+	}
+
+	throw new Error(`Levee server did not become healthy within ${timeoutMs}ms`);
+}
+
+async function startServer(): Promise<void> {
+	console.log("Starting Levee server via Docker Compose...");
+
+	try {
+		await execAsync("docker compose up -d", {
+			cwd: LEVEE_CLIENT_DIR,
+		});
+		console.log("Docker Compose started, waiting for server to be healthy...");
+	} catch (error) {
+		throw new Error(`Failed to start Levee server: ${error}`);
+	}
+}
+
+export async function ensureServerRunning(): Promise<void> {
+	console.log("Checking if Levee server is running...");
+
+	if (await checkHealth()) {
+		console.log("Levee server is already running and healthy");
+		return;
+	}
+
+	console.log("Levee server is not running, starting it...");
+	await startServer();
+	await waitForHealth(HEALTH_CHECK_TIMEOUT_MS);
+	console.log("Levee server is now running and healthy");
+}

--- a/client/packages/levee-todo-list/e2e/todo-list.spec.ts
+++ b/client/packages/levee-todo-list/e2e/todo-list.spec.ts
@@ -1,0 +1,228 @@
+import {
+	expect,
+	getContainerIdFromUrl,
+	test,
+	waitForConnected,
+	waitForTodoView,
+} from "./fixtures/test-fixtures.ts";
+
+test.describe("single user", () => {
+	test("app loads and shows todo list with initial items", async ({
+		connectedPage: page,
+	}) => {
+		// Verify the todo view is rendered
+		await expect(page.locator(".todo-view")).toBeVisible();
+
+		// Should show the default list title
+		const titleInput = page.locator(".todo-title");
+		await expect(titleInput).toBeVisible();
+		await expect(titleInput).toHaveValue("My to-do list");
+
+		// Should show the two initial todo items
+		const items = page.locator(".item-wrap");
+		await expect(items).toHaveCount(2);
+
+		// First item: "Buy groceries" (unchecked)
+		const firstItemInput = items.nth(0).locator(".todo-item-input");
+		await expect(firstItemInput).toHaveValue("Buy groceries");
+		const firstCheckbox = items.nth(0).locator(".todo-item-checkbox");
+		await expect(firstCheckbox).not.toBeChecked();
+
+		// Second item: "Walk the dog" (checked)
+		const secondItemInput = items.nth(1).locator(".todo-item-input");
+		await expect(secondItemInput).toHaveValue("Walk the dog");
+		const secondCheckbox = items.nth(1).locator(".todo-item-checkbox");
+		await expect(secondCheckbox).toBeChecked();
+	});
+
+	test("add new todo item", async ({ connectedPage: page }) => {
+		// Type into the new item input
+		const newItemInput = page.locator(".new-item-text");
+		await newItemInput.fill("Learn Fluid Framework");
+
+		// Click the add button
+		await page.locator(".new-item-button").click();
+
+		// Should now have 3 items
+		const items = page.locator(".item-wrap");
+		await expect(items).toHaveCount(3);
+
+		// The new item should be at the end
+		const newItemText = items.nth(2).locator(".todo-item-input");
+		await expect(newItemText).toHaveValue("Learn Fluid Framework");
+
+		// New item should be unchecked
+		const newCheckbox = items.nth(2).locator(".todo-item-checkbox");
+		await expect(newCheckbox).not.toBeChecked();
+	});
+
+	test("toggle todo item completed", async ({ connectedPage: page }) => {
+		// First item starts unchecked
+		const firstCheckbox = page
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-checkbox");
+		await expect(firstCheckbox).not.toBeChecked();
+
+		// Check it
+		await firstCheckbox.check();
+		await expect(firstCheckbox).toBeChecked();
+
+		// Uncheck it
+		await firstCheckbox.uncheck();
+		await expect(firstCheckbox).not.toBeChecked();
+	});
+
+	test("delete todo item", async ({ connectedPage: page }) => {
+		// Start with 2 items
+		const items = page.locator(".item-wrap");
+		await expect(items).toHaveCount(2);
+
+		// Click the X button on the first item
+		await items.nth(0).locator(".action-button").click();
+
+		// Should now have 1 item
+		await expect(items).toHaveCount(1);
+
+		// The remaining item should be "Walk the dog"
+		const remainingItemInput = items.nth(0).locator(".todo-item-input");
+		await expect(remainingItemInput).toHaveValue("Walk the dog");
+	});
+
+	test("expand and collapse todo item details", async ({
+		connectedPage: page,
+	}) => {
+		// Details should be hidden initially
+		const details = page.locator(".todo-item-details");
+		await expect(details).toHaveCount(0);
+
+		// Click the expand button on the first item
+		const expandButton = page
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-expand-button");
+		await expandButton.click();
+
+		// Details textarea should now be visible
+		await expect(details).toHaveCount(1);
+		await expect(details.first()).toBeVisible();
+
+		// Click again to collapse
+		await expandButton.click();
+		await expect(details).toHaveCount(0);
+	});
+});
+
+test.describe("multi-user collaboration", () => {
+	test("second user sees same todo items", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// Both pages should be connected
+		await expect(page1.locator("#status")).toHaveClass("connected");
+		await expect(page2.locator("#status")).toHaveClass("connected");
+
+		// Both should have the same container ID
+		const containerId1 = getContainerIdFromUrl(page1);
+		const containerId2 = getContainerIdFromUrl(page2);
+		expect(containerId1).toBe(containerId2);
+
+		// Page2 should see the same initial items
+		const items2 = page2.locator(".item-wrap");
+		await expect(items2).toHaveCount(2);
+
+		const firstItemInput2 = items2.nth(0).locator(".todo-item-input");
+		await expect(firstItemInput2).toHaveValue("Buy groceries");
+
+		const secondItemInput2 = items2.nth(1).locator(".todo-item-input");
+		await expect(secondItemInput2).toHaveValue("Walk the dog");
+	});
+
+	test("adding item on one side appears on the other", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// Add a new item on page1
+		const newItemInput = page1.locator(".new-item-text");
+		await newItemInput.fill("Shared task");
+		await page1.locator(".new-item-button").click();
+
+		// Page1 should show 3 items
+		await expect(page1.locator(".item-wrap")).toHaveCount(3);
+
+		// Page2 should also show 3 items after sync
+		await expect(page2.locator(".item-wrap")).toHaveCount(3, {
+			timeout: 10_000,
+		});
+
+		// The new item should appear on page2
+		const newItem2 = page2
+			.locator(".item-wrap")
+			.nth(2)
+			.locator(".todo-item-input");
+		await expect(newItem2).toHaveValue("Shared task");
+	});
+
+	test("checking item syncs across users", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// First item is unchecked on both pages
+		const checkbox1 = page1
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-checkbox");
+		const checkbox2 = page2
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-checkbox");
+
+		await expect(checkbox1).not.toBeChecked();
+		await expect(checkbox2).not.toBeChecked();
+
+		// Check on page1
+		await checkbox1.check();
+
+		// Should sync to page2
+		await expect(checkbox2).toBeChecked({ timeout: 10_000 });
+
+		// Uncheck on page2
+		await checkbox2.uncheck();
+
+		// Should sync back to page1
+		await expect(checkbox1).not.toBeChecked({ timeout: 10_000 });
+	});
+
+	test("deleting item syncs across users", async ({
+		connectedPage: page1,
+		secondUser: { page: page2 },
+	}) => {
+		// Both start with 2 items
+		await expect(page1.locator(".item-wrap")).toHaveCount(2);
+		await expect(page2.locator(".item-wrap")).toHaveCount(2);
+
+		// Delete first item on page1
+		await page1.locator(".item-wrap").nth(0).locator(".action-button").click();
+
+		// Page1 should have 1 item
+		await expect(page1.locator(".item-wrap")).toHaveCount(1);
+
+		// Page2 should also have 1 item after sync
+		await expect(page2.locator(".item-wrap")).toHaveCount(1, {
+			timeout: 10_000,
+		});
+
+		// The remaining item should be "Walk the dog" on both
+		const remaining1 = page1
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-input");
+		const remaining2 = page2
+			.locator(".item-wrap")
+			.nth(0)
+			.locator(".todo-item-input");
+
+		await expect(remaining1).toHaveValue("Walk the dog");
+		await expect(remaining2).toHaveValue("Walk the dog");
+	});
+});

--- a/client/packages/levee-todo-list/index.html
+++ b/client/packages/levee-todo-list/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en" style="height: 100%">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Levee Todo List</title>
+		<style>
+			#status {
+				padding: 8px 16px;
+				font-family: monospace;
+				font-size: 14px;
+				background: #f0f0f0;
+				border-bottom: 1px solid #ddd;
+			}
+			#status.connected {
+				background: #d4edda;
+				color: #155724;
+			}
+			#status.error {
+				background: #f8d7da;
+				color: #721c24;
+			}
+		</style>
+	</head>
+	<body style="margin: 0; height: 100%">
+		<div id="status">Initializing...</div>
+		<div id="content" style="min-height: 100%"></div>
+		<script type="module" src="/src/app.tsx"></script>
+	</body>
+</html>

--- a/client/packages/levee-todo-list/package.json
+++ b/client/packages/levee-todo-list/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@tylerbu/levee-todo-list",
+	"version": "0.0.1",
+	"private": true,
+	"description": "Collaborative todo-list example using Levee client and Fluid Framework SharedTree",
+	"bugs": "https://github.com/tylerbutler/levee/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/levee.git",
+		"directory": "client/packages/levee-todo-list"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:vite": "vite build",
+		"check:format": "biome format .",
+		"clean": "rimraf esm dist _temp *.tsbuildinfo",
+		"dev": "vite",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"test:e2e": "playwright test",
+		"test:e2e:headed": "playwright test --headed",
+		"test:e2e:ui": "playwright test --ui"
+	},
+	"dependencies": {
+		"@fluidframework/core-interfaces": "~2.81.0",
+		"@fluidframework/merge-tree": "~2.81.0",
+		"@fluidframework/react": "~2.81.0",
+		"@fluidframework/sequence": "~2.81.0",
+		"@fluidframework/shared-object-base": "~2.81.0",
+		"@tylerbu/levee-client": "workspace:^",
+		"fluid-framework": "~2.81.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@playwright/test": "^1.50.0",
+		"@types/node": "^20.19.25",
+		"@types/react": "^18.3.18",
+		"@types/react-dom": "^18.3.5",
+		"@vitejs/plugin-react": "^4.5.2",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vite": "^7.3.0"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
+}

--- a/client/packages/levee-todo-list/playwright.config.ts
+++ b/client/packages/levee-todo-list/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./e2e",
+	timeout: 60_000,
+	expect: {
+		timeout: 10_000,
+	},
+	fullyParallel: false, // Run tests sequentially to avoid port conflicts
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 1,
+	workers: 1, // Single worker for WebSocket-based tests
+	reporter: process.env.CI ? "github" : "list",
+
+	globalSetup: "./e2e/global-setup.ts",
+
+	use: {
+		baseURL: "http://localhost:3001",
+		trace: "on-first-retry",
+		video: "on-first-retry",
+	},
+
+	webServer: {
+		command: "pnpm dev",
+		url: "http://localhost:3001",
+		reuseExistingServer: false, // Always start fresh to avoid module caching
+		timeout: 30_000,
+	},
+
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+});

--- a/client/packages/levee-todo-list/src/app.tsx
+++ b/client/packages/levee-todo-list/src/app.tsx
@@ -1,0 +1,115 @@
+import { LeveeClient } from "@tylerbu/levee-client";
+import type { IFluidContainer } from "fluid-framework";
+import { createRoot } from "react-dom/client";
+
+import {
+	initializeAppForNewContainer,
+	loadAppFromExistingContainer,
+	type TodoListContainerSchema,
+	todoListContainerSchema,
+} from "./fluid.js";
+import type { TodoList } from "./schema.js";
+import { TodoListAppView } from "./view.js";
+
+// Default configuration values
+// In dev mode, requests are proxied through Vite to avoid CORS issues
+const LEVEE_HTTP_URL =
+	import.meta.env["VITE_LEVEE_HTTP_URL"] ||
+	(import.meta.env.DEV ? window.location.origin : "http://localhost:4000");
+const LEVEE_SOCKET_URL =
+	import.meta.env["VITE_LEVEE_SOCKET_URL"] ||
+	(import.meta.env.DEV
+		? `ws://${window.location.host}/socket`
+		: "ws://localhost:4000/socket");
+const LEVEE_TENANT_KEY =
+	import.meta.env["VITE_LEVEE_TENANT_KEY"] || "dev-tenant-secret-key";
+
+/**
+ * Updates the status indicator in the UI.
+ */
+function setStatus(
+	message: string,
+	isError = false,
+	isConnected = false,
+): void {
+	const statusDiv = document.querySelector("#status");
+	if (statusDiv) {
+		statusDiv.textContent = message;
+		statusDiv.className = isError ? "error" : isConnected ? "connected" : "";
+	}
+}
+
+/**
+ * Start the todo-list app.
+ */
+async function start(): Promise<void> {
+	setStatus("Connecting to Levee server...");
+
+	// Create a unique user ID for this session
+	const userId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+	const client = new LeveeClient({
+		connection: {
+			httpUrl: LEVEE_HTTP_URL,
+			socketUrl: LEVEE_SOCKET_URL,
+			tenantKey: LEVEE_TENANT_KEY,
+			user: {
+				id: userId,
+				name: `User ${userId.slice(-5)}`,
+			},
+		},
+	});
+
+	let container: IFluidContainer<TodoListContainerSchema>;
+	let containerId: string;
+	let appModel: TodoList;
+
+	const createNew = location.hash.length === 0;
+	if (createNew) {
+		setStatus("Creating new container...");
+		({ container } = await client.createContainer(
+			todoListContainerSchema,
+			"2",
+		));
+
+		// Initialize the app model for the new container
+		appModel = await initializeAppForNewContainer(container);
+
+		// Attach the container to the service
+		containerId = await container.attach();
+
+		// Update the URL hash with the container ID
+		location.hash = containerId;
+	} else {
+		containerId = location.hash.slice(1);
+		setStatus(`Loading container ${containerId}...`);
+
+		({ container } = await client.getContainer(
+			containerId,
+			todoListContainerSchema,
+			"2",
+		));
+		appModel = loadAppFromExistingContainer(container);
+	}
+
+	setStatus(`Connected: ${containerId}`, false, true);
+	document.title = `Todo List - ${containerId}`;
+
+	// Render the React application
+	const contentDiv = document.querySelector("#content") as HTMLDivElement;
+	const root = createRoot(contentDiv);
+	root.render(<TodoListAppView todoList={appModel} container={container} />);
+
+	console.info("Connected to Levee server");
+	console.info("Container ID:", containerId);
+	console.info("User ID:", userId);
+}
+
+// Start the application
+start().catch((error) => {
+	console.error("Failed to start application:", error);
+	setStatus(
+		`Error: ${error instanceof Error ? error.message : String(error)}`,
+		true,
+	);
+});

--- a/client/packages/levee-todo-list/src/collaborative-inputs/CollaborativeInput.tsx
+++ b/client/packages/levee-todo-list/src/collaborative-inputs/CollaborativeInput.tsx
@@ -1,0 +1,153 @@
+import type {
+	SequenceDeltaEvent,
+	SharedString,
+} from "@fluidframework/sequence/legacy";
+import {
+	Component,
+	type CSSProperties,
+	createRef,
+	type FormEvent,
+	type RefObject,
+} from "react";
+
+/**
+ * {@link CollaborativeInput} input props.
+ */
+export interface ICollaborativeInputProps {
+	/**
+	 * The SharedString that will store the input value.
+	 */
+	sharedString: SharedString;
+
+	/**
+	 * Whether or not the control should be read-only.
+	 * @defaultValue `false`
+	 */
+	readOnly?: boolean;
+
+	/**
+	 * Whether spellCheck should be enabled.
+	 * @defaultValue `true`
+	 */
+	spellCheck?: boolean;
+	className?: string;
+	style?: CSSProperties;
+	disabled?: boolean;
+	onInput?: (sharedString: SharedString) => void;
+}
+
+/**
+ * {@link CollaborativeInput} component state.
+ */
+interface ICollaborativeInputState {
+	selectionEnd: number;
+	selectionStart: number;
+}
+
+/**
+ * Given a SharedString, produces a collaborative input element.
+ */
+export class CollaborativeInput extends Component<
+	ICollaborativeInputProps,
+	ICollaborativeInputState
+> {
+	private readonly inputElementRef: RefObject<HTMLInputElement>;
+
+	constructor(props: ICollaborativeInputProps) {
+		super(props);
+
+		this.inputElementRef = createRef<HTMLInputElement>();
+
+		this.state = {
+			selectionEnd: 0,
+			selectionStart: 0,
+		};
+
+		this.handleInput = this.handleInput.bind(this);
+		this.updateSelection = this.updateSelection.bind(this);
+	}
+
+	public override componentDidMount(): void {
+		this.props.sharedString.on("sequenceDelta", (ev: SequenceDeltaEvent) => {
+			if (!ev.isLocal) {
+				this.updateInputFromSharedString();
+			}
+		});
+		this.updateInputFromSharedString();
+	}
+
+	public override componentDidUpdate(
+		prevProps: ICollaborativeInputProps,
+	): void {
+		if (prevProps.sharedString !== this.props.sharedString) {
+			this.updateInputFromSharedString();
+		}
+	}
+
+	public override render(): JSX.Element {
+		return (
+			<input
+				className={this.props.className}
+				style={this.props.style}
+				readOnly={this.props.readOnly ?? false}
+				spellCheck={this.props.spellCheck ?? true}
+				ref={this.inputElementRef}
+				disabled={this.props.disabled}
+				onBeforeInput={this.updateSelection}
+				onKeyDown={this.updateSelection}
+				onClick={this.updateSelection}
+				onContextMenu={this.updateSelection}
+				onInput={this.handleInput}
+			/>
+		);
+	}
+
+	private updateInputFromSharedString(): void {
+		const text = this.props.sharedString.getText();
+		if (
+			this.inputElementRef.current &&
+			this.inputElementRef.current.value !== text
+		) {
+			this.inputElementRef.current.value = text;
+		}
+	}
+
+	private readonly handleInput = (ev: FormEvent<HTMLInputElement>): void => {
+		const newText = ev.currentTarget.value;
+		const newPosition = ev.currentTarget.selectionStart ?? 0;
+		const isTextInserted = newPosition - this.state.selectionStart > 0;
+		if (isTextInserted) {
+			const insertedText = newText.slice(
+				this.state.selectionStart,
+				newPosition,
+			);
+			const changeRangeLength =
+				this.state.selectionEnd - this.state.selectionStart;
+			if (changeRangeLength === 0) {
+				this.props.sharedString.insertText(
+					this.state.selectionStart,
+					insertedText,
+				);
+			} else {
+				this.props.sharedString.replaceText(
+					this.state.selectionStart,
+					this.state.selectionEnd,
+					insertedText,
+				);
+			}
+		} else {
+			this.props.sharedString.removeText(newPosition, this.state.selectionEnd);
+		}
+		this.props.onInput?.(this.props.sharedString);
+	};
+
+	private readonly updateSelection = (): void => {
+		if (!this.inputElementRef.current) {
+			return;
+		}
+
+		const selectionEnd = this.inputElementRef.current.selectionEnd ?? 0;
+		const selectionStart = this.inputElementRef.current.selectionStart ?? 0;
+		this.setState({ selectionEnd, selectionStart });
+	};
+}

--- a/client/packages/levee-todo-list/src/collaborative-inputs/CollaborativeTextArea.tsx
+++ b/client/packages/levee-todo-list/src/collaborative-inputs/CollaborativeTextArea.tsx
@@ -1,0 +1,167 @@
+import {
+	type CSSProperties,
+	type FC,
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+import type {
+	ISharedStringHelperTextChangedEventArgs,
+	SharedStringHelper,
+} from "./SharedStringHelper.js";
+
+/**
+ * {@link CollaborativeTextArea} input props.
+ */
+export interface ICollaborativeTextAreaProps {
+	/**
+	 * The SharedStringHelper that will store the text from the textarea.
+	 */
+	sharedStringHelper: SharedStringHelper;
+
+	/**
+	 * Whether or not the control should be read-only.
+	 * @defaultValue `false`
+	 */
+	readOnly?: boolean;
+
+	/**
+	 * Whether `spellCheck` should be enabled.
+	 * @defaultValue `false`
+	 */
+	spellCheck?: boolean;
+
+	className?: string;
+	style?: CSSProperties;
+}
+
+/**
+ * Given a SharedStringHelper, produces a collaborative text area element.
+ */
+export const CollaborativeTextArea: FC<ICollaborativeTextAreaProps> = (
+	props: ICollaborativeTextAreaProps,
+) => {
+	const { sharedStringHelper, readOnly, spellCheck, className, style } = props;
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const selectionStartRef = useRef<number>(0);
+	const selectionEndRef = useRef<number>(0);
+
+	const [text, setText] = useState<string>(sharedStringHelper.getText());
+
+	/**
+	 * Set the selection in the DOM textarea itself.
+	 */
+	const setTextareaSelection = useCallback(
+		(newStart: number, newEnd: number): void => {
+			if (!textareaRef.current) {
+				throw new Error(
+					"Trying to set selection without current textarea ref?",
+				);
+			}
+			const textareaElement = textareaRef.current;
+			textareaElement.selectionStart = newStart;
+			textareaElement.selectionEnd = newEnd;
+		},
+		[],
+	);
+
+	/**
+	 * Take the current selection from the DOM textarea and store it in React refs.
+	 */
+	const storeSelectionInReact = useCallback((): void => {
+		if (!textareaRef.current) {
+			throw new Error(
+				"Trying to remember selection without current textarea ref?",
+			);
+		}
+		const textareaElement = textareaRef.current;
+		selectionStartRef.current = textareaElement.selectionStart;
+		selectionEndRef.current = textareaElement.selectionEnd;
+	}, []);
+
+	/**
+	 * Handle local changes to the textarea content.
+	 */
+	const handleChange = (_ev: FormEvent<HTMLTextAreaElement>): void => {
+		if (!textareaRef.current) {
+			throw new Error("Handling change without current textarea ref?");
+		}
+		const textareaElement = textareaRef.current;
+		const newText = textareaElement.value;
+		const newCaretPosition = textareaElement.selectionStart;
+
+		const oldText = text;
+		const oldSelectionStart = selectionStartRef.current;
+		const oldSelectionEnd = selectionEndRef.current;
+
+		storeSelectionInReact();
+		setText(newText);
+
+		const isTextInserted = newCaretPosition - oldSelectionStart > 0;
+		if (isTextInserted) {
+			const insertedText = newText.slice(oldSelectionStart, newCaretPosition);
+			const isTextReplaced = oldSelectionEnd - oldSelectionStart > 0;
+			if (isTextReplaced) {
+				sharedStringHelper.replaceText(
+					insertedText,
+					oldSelectionStart,
+					oldSelectionEnd,
+				);
+			} else {
+				sharedStringHelper.insertText(insertedText, oldSelectionStart);
+			}
+		} else {
+			const charactersDeleted = oldText.length - newText.length;
+			sharedStringHelper.removeText(
+				newCaretPosition,
+				newCaretPosition + charactersDeleted,
+			);
+		}
+	};
+
+	useEffect(() => {
+		const handleTextChanged = (
+			event: ISharedStringHelperTextChangedEventArgs,
+		): void => {
+			const newText = sharedStringHelper.getText();
+			setText(newText);
+
+			if (!event.isLocal) {
+				const newSelectionStart = event.transformPosition(
+					selectionStartRef.current,
+				);
+				const newSelectionEnd = event.transformPosition(
+					selectionEndRef.current,
+				);
+				setTextareaSelection(newSelectionStart, newSelectionEnd);
+				storeSelectionInReact();
+			}
+		};
+
+		sharedStringHelper.on("textChanged", handleTextChanged);
+		return () => {
+			sharedStringHelper.off("textChanged", handleTextChanged);
+		};
+	}, [sharedStringHelper, setTextareaSelection, storeSelectionInReact]);
+
+	return (
+		<textarea
+			rows={20}
+			cols={50}
+			ref={textareaRef}
+			className={className}
+			style={style}
+			spellCheck={spellCheck ?? false}
+			readOnly={readOnly ?? false}
+			onBeforeInput={storeSelectionInReact}
+			onKeyDown={storeSelectionInReact}
+			onClick={storeSelectionInReact}
+			onContextMenu={storeSelectionInReact}
+			onChange={handleChange}
+			value={text}
+		/>
+	);
+};

--- a/client/packages/levee-todo-list/src/collaborative-inputs/SharedStringHelper.ts
+++ b/client/packages/levee-todo-list/src/collaborative-inputs/SharedStringHelper.ts
@@ -1,0 +1,121 @@
+import { MergeTreeDeltaType } from "@fluidframework/merge-tree/legacy";
+import type {
+	SequenceDeltaEvent,
+	SharedString,
+} from "@fluidframework/sequence/legacy";
+
+import { TypedEventEmitter } from "./TypedEventEmitter.js";
+
+export interface ISharedStringHelperTextChangedEventArgs {
+	/**
+	 * Whether the change originated from the local client.
+	 */
+	isLocal: boolean;
+
+	/**
+	 * A callback function that translates pre-change positions in the sequence into
+	 * post-change positions (e.g. to track caret position after remote changes).
+	 */
+	transformPosition: (oldPosition: number) => number;
+}
+
+interface ISharedStringHelperEvents {
+	[key: string]: unknown[];
+	textChanged: [ISharedStringHelperTextChangedEventArgs];
+}
+
+/**
+ * Given a SharedString, provides a friendly API for use with collaborative text inputs.
+ */
+export class SharedStringHelper extends TypedEventEmitter<ISharedStringHelperEvents> {
+	private readonly _sharedString: SharedString;
+	private _latestText: string;
+
+	constructor(sharedString: SharedString) {
+		super();
+		this._sharedString = sharedString;
+		this._latestText = this._sharedString.getText();
+		this._sharedString.on("sequenceDelta", this.sequenceDeltaHandler);
+	}
+
+	/**
+	 * Gets the full text stored in the SharedString as a string.
+	 */
+	public getText(): string {
+		return this._latestText;
+	}
+
+	/**
+	 * Insert the string provided at the given position.
+	 */
+	public insertText(text: string, pos: number): void {
+		this._sharedString.insertText(pos, text);
+	}
+
+	/**
+	 * Remove the text within the given range.
+	 */
+	public removeText(start: number, end: number): void {
+		this._sharedString.removeText(start, end);
+	}
+
+	/**
+	 * Insert the string provided at the given start position, and remove the text that
+	 * (prior to the insertion) is within the given range.
+	 */
+	public replaceText(text: string, start: number, end: number): void {
+		this._sharedString.replaceText(start, end, text);
+	}
+
+	/**
+	 * Called when the data of the SharedString changes. Updates cached text and emits
+	 * the "textChanged" event with a transformPosition function for caret tracking.
+	 */
+	private readonly sequenceDeltaHandler = (event: SequenceDeltaEvent): void => {
+		this._latestText = this._sharedString.getText();
+		const isLocal = event.isLocal;
+
+		const op = event.opArgs.op;
+		let transformPosition: (oldPosition: number) => number;
+		if (op.type === MergeTreeDeltaType.INSERT) {
+			transformPosition = (oldPosition: number): number => {
+				if (op.pos1 === undefined) {
+					throw new Error("pos1 undefined");
+				}
+				if (op.seg === undefined) {
+					throw new Error("seg undefined");
+				}
+				const changeStartPosition = op.pos1;
+				const changeLength = (op.seg as string).length;
+				return oldPosition <= changeStartPosition
+					? oldPosition
+					: oldPosition + changeLength;
+			};
+		} else if (op.type === MergeTreeDeltaType.REMOVE) {
+			transformPosition = (oldPosition: number): number => {
+				if (op.pos1 === undefined) {
+					throw new Error("pos1 undefined");
+				}
+				if (op.pos2 === undefined) {
+					throw new Error("pos2 undefined");
+				}
+				const changeStartPosition = op.pos1;
+				const changeEndPosition = op.pos2;
+				const changeLength = changeEndPosition - changeStartPosition;
+				if (oldPosition <= changeStartPosition) {
+					return oldPosition;
+				}
+				if (oldPosition > changeEndPosition - 1) {
+					return oldPosition - changeLength;
+				}
+				return changeStartPosition;
+			};
+		} else {
+			throw new Error(
+				"Don't know how to handle op types beyond insert and remove",
+			);
+		}
+
+		this.emit("textChanged", { isLocal, transformPosition });
+	};
+}

--- a/client/packages/levee-todo-list/src/collaborative-inputs/TypedEventEmitter.ts
+++ b/client/packages/levee-todo-list/src/collaborative-inputs/TypedEventEmitter.ts
@@ -1,0 +1,64 @@
+/**
+ * TypedEventEmitter - a simple typed event emitter implementation.
+ */
+
+/**
+ * Event signature type for typed events.
+ */
+export type EventListener<T extends unknown[]> = (...args: T) => void;
+
+/**
+ * Event map type - maps event names to argument tuples.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: needed for generic event map
+export type EventMap = { [K: string]: any[] };
+
+/**
+ * A simple typed event emitter that provides type-safe event handling.
+ */
+export class TypedEventEmitter<TEvents extends EventMap> {
+	private readonly listeners = new Map<
+		string,
+		Set<(...args: unknown[]) => void>
+	>();
+
+	/**
+	 * Register an event listener.
+	 */
+	public on<K extends keyof TEvents & string>(
+		event: K,
+		listener: (...args: TEvents[K]) => void,
+	): this {
+		if (!this.listeners.has(event)) {
+			this.listeners.set(event, new Set());
+		}
+		this.listeners.get(event)?.add(listener as (...args: unknown[]) => void);
+		return this;
+	}
+
+	/**
+	 * Remove an event listener.
+	 */
+	public off<K extends keyof TEvents & string>(
+		event: K,
+		listener: (...args: TEvents[K]) => void,
+	): this {
+		this.listeners.get(event)?.delete(listener as (...args: unknown[]) => void);
+		return this;
+	}
+
+	/**
+	 * Emit an event to all registered listeners.
+	 */
+	protected emit<K extends keyof TEvents & string>(
+		event: K,
+		...args: TEvents[K]
+	): void {
+		const eventListeners = this.listeners.get(event);
+		if (eventListeners) {
+			for (const listener of eventListeners) {
+				listener(...args);
+			}
+		}
+	}
+}

--- a/client/packages/levee-todo-list/src/collaborative-inputs/index.ts
+++ b/client/packages/levee-todo-list/src/collaborative-inputs/index.ts
@@ -1,0 +1,6 @@
+export type { ICollaborativeInputProps } from "./CollaborativeInput.js";
+export { CollaborativeInput } from "./CollaborativeInput.js";
+export type { ICollaborativeTextAreaProps } from "./CollaborativeTextArea.js";
+export { CollaborativeTextArea } from "./CollaborativeTextArea.js";
+export type { ISharedStringHelperTextChangedEventArgs } from "./SharedStringHelper.js";
+export { SharedStringHelper } from "./SharedStringHelper.js";

--- a/client/packages/levee-todo-list/src/fluid.ts
+++ b/client/packages/levee-todo-list/src/fluid.ts
@@ -1,0 +1,128 @@
+import {
+	type ContainerSchema,
+	type IFluidContainer,
+	SharedTree,
+	TreeViewConfiguration,
+} from "fluid-framework";
+import { SharedString } from "fluid-framework/legacy";
+
+import { TodoItem, TodoList } from "./schema.js";
+
+/**
+ * Schema for the TODO list application.
+ *
+ * This includes the DataObjects we support and any initial DataObjects we want created
+ * when the Container is first created.
+ */
+export const todoListContainerSchema = {
+	initialObjects: {
+		tree: SharedTree,
+	},
+	// This application leverages nested `SharedString` DDSs within the root `SharedTree` DDS.
+	// To allow dynamic creation of `SharedString`s, we need to specify it as a dynamic object type.
+	dynamicObjectTypes: [SharedString],
+} as const satisfies ContainerSchema;
+
+/**
+ * Container schema type for the Todo List application.
+ */
+export type TodoListContainerSchema = typeof todoListContainerSchema;
+
+const treeViewConfig = new TreeViewConfiguration({
+	schema: TodoList,
+	enableSchemaValidation: true,
+});
+
+/**
+ * Loads the application model from an existing Fluid Container.
+ */
+export function loadAppFromExistingContainer(
+	container: IFluidContainer<TodoListContainerSchema>,
+): TodoList {
+	const tree = container.initialObjects.tree;
+	const treeView = tree.viewWith(treeViewConfig);
+	if (!treeView.compatibility.canView) {
+		throw new Error("Expected container data to be compatible with app schema");
+	}
+	return treeView.root;
+}
+
+/**
+ * Initializes the application model for a newly created Fluid Container.
+ *
+ * Includes population of the initial TodoList contents.
+ */
+export async function initializeAppForNewContainer(
+	container: IFluidContainer<TodoListContainerSchema>,
+): Promise<TodoList> {
+	const tree = container.initialObjects.tree;
+	const treeView = tree.viewWith(treeViewConfig);
+	if (!treeView.compatibility.canInitialize) {
+		throw new Error(
+			"Expected container data to be compatible with TodoList schema",
+		);
+	}
+
+	const initialTodoList = await createInitialTodoList(container);
+	treeView.initialize(initialTodoList);
+
+	return treeView.root;
+}
+
+/**
+ * Create the initial `TodoList` tree for the application.
+ */
+async function createInitialTodoList(
+	container: IFluidContainer,
+): Promise<TodoList> {
+	// Generate a new `SharedString` for the `TodoList` title.
+	const listTitle = await container.create(SharedString);
+	listTitle.insertText(0, "My to-do list");
+
+	// Create our 2 initial `TodoItem`s.
+	const todoItem1 = await createTodoItem({
+		container,
+		completed: false,
+		initialTitleText: "Buy groceries",
+	});
+	const todoItem2 = await createTodoItem({
+		container,
+		completed: true,
+		initialTitleText: "Walk the dog",
+	});
+
+	return new TodoList({
+		title: listTitle.handle,
+		items: [todoItem1, todoItem2],
+	});
+}
+
+/**
+ * Creates a new {@link TodoItem}, using the provided Fluid container to generate `SharedString`
+ * DDSs for use as the item's title and description.
+ */
+export async function createTodoItem({
+	container,
+	completed,
+	initialTitleText,
+	initialDescriptionText,
+}: {
+	container: IFluidContainer;
+	completed: boolean;
+	initialTitleText?: string;
+	initialDescriptionText?: string;
+}): Promise<TodoItem> {
+	const title = await container.create(SharedString);
+	if (initialTitleText !== undefined) {
+		title.insertText(0, initialTitleText);
+	}
+	const description = await container.create(SharedString);
+	if (initialDescriptionText !== undefined) {
+		description.insertText(0, initialDescriptionText);
+	}
+	return new TodoItem({
+		title: title.handle,
+		description: description.handle,
+		completed,
+	});
+}

--- a/client/packages/levee-todo-list/src/schema.ts
+++ b/client/packages/levee-todo-list/src/schema.ts
@@ -1,0 +1,43 @@
+import { SchemaFactory } from "fluid-framework";
+
+const schemaFactory = new SchemaFactory("fluid-example-todo-list");
+
+/**
+ * An item in a to-do list.
+ */
+export class TodoItem extends schemaFactory.object("TodoItem", {
+	/**
+	 * A unique identifier for the to-do item.
+	 */
+	id: schemaFactory.identifier,
+
+	/**
+	 * Handle to a `SharedString` representing the to-do item's title.
+	 */
+	title: schemaFactory.handle,
+
+	/**
+	 * Handle to a `SharedString` representing the to-do item's description.
+	 */
+	description: schemaFactory.handle,
+
+	/**
+	 * Whether or not the item is completed
+	 */
+	completed: schemaFactory.boolean,
+}) {}
+
+/**
+ * A to-do list, comprised of {@link TodoItem}s.
+ */
+export class TodoList extends schemaFactory.object("TodoList", {
+	/**
+	 * Handle to a `SharedString` representing the to-do list's title.
+	 */
+	title: schemaFactory.handle,
+
+	/**
+	 * The list's to-do items
+	 */
+	items: schemaFactory.array(TodoItem),
+}) {}

--- a/client/packages/levee-todo-list/src/style.css
+++ b/client/packages/levee-todo-list/src/style.css
@@ -1,0 +1,98 @@
+.todo-view {
+	max-width: 800px;
+	margin: 0 auto;
+	padding: 0 15px;
+}
+
+.todo-title {
+	width: 100%;
+	border: none;
+	font-size: 50px;
+	text-align: center;
+	margin-bottom: 5px;
+	margin-top: 5px;
+	outline: none;
+}
+
+.new-item-form {
+	margin: 20px 0;
+}
+
+.new-item-text {
+	box-sizing: border-box;
+	width: calc(100% - 50px);
+	height: 50px;
+	border: 1px solid #666;
+	vertical-align: middle;
+	font-size: 30px;
+	outline: 0;
+}
+
+.new-item-button {
+	width: 50px;
+	height: 50px;
+	border: 1px solid #666;
+	vertical-align: middle;
+	font-size: 30px;
+}
+
+.item-wrap {
+	display: flex;
+}
+
+.todo-item-view {
+	display: inline-block;
+	width: calc(100% - 100px);
+}
+
+.action-button {
+	box-sizing: border-box;
+	width: 50px;
+	height: 50px;
+	margin: 10px 0 10px 10px;
+	border: 1px solid #666;
+	padding: 0;
+	font-size: 30px;
+}
+
+.action-button:last-child {
+	margin: 10px;
+}
+
+.todo-item-header {
+	margin: 0;
+	display: flex;
+}
+
+.todo-item-expand-button {
+	box-sizing: border-box;
+	width: 30px;
+	height: 50px;
+	margin: 10px 0 10px 10px;
+	border: none;
+	padding: 0;
+	font-size: 30px;
+	background: none;
+}
+
+.todo-item-checkbox {
+	box-sizing: border-box;
+	width: 50px;
+	height: 50px;
+	margin: 10px 0 10px 10px;
+}
+
+.todo-item-input {
+	box-sizing: border-box;
+	border: none;
+	width: 100%;
+	height: 50px;
+	margin: 10px 0 10px 10px;
+	padding: 0;
+	font-size: 20px;
+	outline: none;
+}
+
+.todo-item-details {
+	width: 100%;
+}

--- a/client/packages/levee-todo-list/src/view.tsx
+++ b/client/packages/levee-todo-list/src/view.tsx
@@ -1,0 +1,212 @@
+import { useTree } from "@fluidframework/react/alpha";
+import type { IFluidContainer, IFluidHandle } from "fluid-framework";
+import type { ISharedString } from "fluid-framework/legacy";
+import {
+	type ChangeEvent,
+	type FC,
+	type FormEvent,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+import {
+	CollaborativeInput,
+	CollaborativeTextArea,
+	SharedStringHelper,
+} from "./collaborative-inputs/index.js";
+import { createTodoItem, type TodoListContainerSchema } from "./fluid.js";
+import type { TodoItem, TodoList } from "./schema.js";
+
+import "./style.css";
+
+/**
+ * {@link TodoListAppView} input props.
+ */
+export interface TodoListAppViewProps {
+	readonly todoList: TodoList;
+	readonly container: IFluidContainer<TodoListContainerSchema>;
+}
+
+/**
+ * To-do list application view component.
+ */
+export const TodoListAppView: FC<TodoListAppViewProps> = (
+	props: TodoListAppViewProps,
+) => {
+	const { todoList, container } = props;
+
+	const [titleString, setTitleString] = useState<ISharedString | undefined>();
+
+	const newItemTextInputRef = useRef<HTMLInputElement>(null);
+	useTree(todoList);
+
+	const todoListTitleHandle = todoList.title as IFluidHandle<ISharedString>;
+
+	useEffect(() => {
+		todoListTitleHandle
+			.get()
+			.then((title) => {
+				setTitleString(title);
+			})
+			.catch((error) => {
+				console.error("Failed to get to-do list title:", error);
+				throw error;
+			});
+	}, [todoListTitleHandle]);
+
+	if (titleString === undefined) {
+		return <div>Loading...</div>;
+	}
+
+	const handleCreateClick = (ev: FormEvent<HTMLFormElement>): void => {
+		ev.preventDefault();
+
+		const input = newItemTextInputRef.current;
+		if (input === null) {
+			throw new Error("New item text field missing");
+		}
+		const valueToInsert = input.value;
+		input.value = "";
+
+		createTodoItem({
+			container,
+			initialTitleText: valueToInsert,
+			completed: false,
+		})
+			.then((todoItem) => {
+				todoList.items.insertAtEnd(todoItem);
+			})
+			.catch((error) => {
+				console.error("Failed to create to-do item:", error);
+				throw error;
+			});
+	};
+
+	// Using the list of TodoItem objects, make a list of TodoItemViews.
+	const todoItemViews = todoList.items.map((todoItem, index) => (
+		<div className="item-wrap" key={todoItem.id}>
+			<TodoItemView todoItem={todoItem} />
+			<button
+				className="action-button"
+				onClick={() => {
+					todoList.items.removeAt(index);
+				}}
+				type="button"
+			>
+				X
+			</button>
+		</div>
+	));
+
+	return (
+		<div className="todo-view">
+			<CollaborativeInput className="todo-title" sharedString={titleString} />
+			<form className="new-item-form" onSubmit={handleCreateClick}>
+				<input
+					className="new-item-text"
+					type="text"
+					ref={newItemTextInputRef}
+					name="itemName"
+					placeholder="Add a new to-do item..."
+				/>
+				<button className="new-item-button" type="submit" name="createItem">
+					+
+				</button>
+			</form>
+			<div className="todo-item-list">{todoItemViews}</div>
+		</div>
+	);
+};
+
+/**
+ * {@link TodoItemView} input props.
+ */
+interface TodoItemViewProps {
+	readonly todoItem: TodoItem;
+}
+
+/**
+ * To-do list item view component.
+ */
+const TodoItemView: FC<TodoItemViewProps> = (props: TodoItemViewProps) => {
+	const { todoItem } = props;
+
+	const [itemTitle, setItemTitle] = useState<ISharedString | undefined>(
+		undefined,
+	);
+	const [itemDescription, setItemDescription] = useState<
+		ISharedString | undefined
+	>(undefined);
+	const [detailsVisible, setDetailsVisible] = useState<boolean>(false);
+
+	useTree(todoItem);
+
+	const todoItemTitleHandle = todoItem.title as IFluidHandle<ISharedString>;
+	useEffect(() => {
+		todoItemTitleHandle
+			.get()
+			.then((text) => {
+				setItemTitle(text);
+			})
+			.catch((error) => {
+				console.error("Failed to get to-do item title:", error);
+				throw error;
+			});
+	}, [todoItemTitleHandle]);
+
+	const todoItemDescriptionHandle =
+		todoItem.description as IFluidHandle<ISharedString>;
+	useEffect(() => {
+		todoItemDescriptionHandle
+			.get()
+			.then((text) => {
+				setItemDescription(text);
+			})
+			.catch((error) => {
+				console.error("Failed to get to-do item description:", error);
+				throw error;
+			});
+	}, [todoItemDescriptionHandle]);
+
+	const checkChangedHandler = (e: ChangeEvent<HTMLInputElement>): void => {
+		todoItem.completed = e.target.checked;
+	};
+
+	if (itemTitle === undefined || itemDescription === undefined) {
+		return <div>Loading item...</div>;
+	}
+
+	return (
+		<div className="todo-item">
+			<h2 className="todo-item-header">
+				<input
+					type="checkbox"
+					className="todo-item-checkbox"
+					checked={todoItem.completed}
+					onChange={checkChangedHandler}
+				/>
+				<button
+					className="todo-item-expand-button"
+					name="toggleDetailsVisible"
+					onClick={() => {
+						setDetailsVisible(!detailsVisible);
+					}}
+					type="button"
+				>
+					{detailsVisible ? "\u25B2" : "\u25BC"}
+				</button>
+				<CollaborativeInput
+					sharedString={itemTitle}
+					className="todo-item-input"
+				/>
+			</h2>
+			{detailsVisible && (
+				<CollaborativeTextArea
+					className="todo-item-details"
+					sharedStringHelper={new SharedStringHelper(itemDescription)}
+				/>
+			)}
+		</div>
+	);
+};

--- a/client/packages/levee-todo-list/src/vite-env.d.ts
+++ b/client/packages/levee-todo-list/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/packages/levee-todo-list/tsconfig.json
+++ b/client/packages/levee-todo-list/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.strict.json",
+	"compilerOptions": {
+		"outDir": "./esm",
+		"rootDir": "./src",
+		"jsx": "react-jsx",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"]
+	},
+	"include": ["src/**/*"],
+	"references": [
+		{
+			"path": "../levee-client"
+		}
+	]
+}

--- a/client/packages/levee-todo-list/vite.config.ts
+++ b/client/packages/levee-todo-list/vite.config.ts
@@ -1,0 +1,53 @@
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [react()],
+	build: {
+		outDir: "dist",
+		sourcemap: true,
+	},
+	optimizeDeps: {
+		// Exclude workspace dependencies from pre-bundling to use latest source
+		exclude: ["@tylerbu/levee-client", "@tylerbu/levee-driver"],
+		// Force re-bundling on every server start
+		force: true,
+	},
+	resolve: {
+		alias: {
+			// Point to compiled ESM output directly to bypass any caching
+			"@tylerbu/levee-driver": resolve(
+				__dirname,
+				"../levee-driver/esm/index.js",
+			),
+			"@tylerbu/levee-client": resolve(
+				__dirname,
+				"../levee-client/esm/index.js",
+			),
+		},
+	},
+	server: {
+		port: 3001,
+		open: true,
+		proxy: {
+			// Proxy API requests to Levee server to avoid CORS issues
+			"/documents": {
+				target: "http://localhost:4000",
+				changeOrigin: true,
+			},
+			"/deltas": {
+				target: "http://localhost:4000",
+				changeOrigin: true,
+			},
+			"/repos": {
+				target: "http://localhost:4000",
+				changeOrigin: true,
+			},
+			"/socket": {
+				target: "ws://localhost:4000",
+				ws: true,
+			},
+		},
+	},
+});

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -310,6 +310,64 @@ importers:
         specifier: ^7.3.0
         version: 7.3.1(@types/node@20.19.33)(yaml@2.8.2)
 
+  packages/levee-todo-list:
+    dependencies:
+      '@fluidframework/core-interfaces':
+        specifier: ~2.81.0
+        version: 2.81.1
+      '@fluidframework/merge-tree':
+        specifier: ~2.81.0
+        version: 2.81.1
+      '@fluidframework/react':
+        specifier: ~2.81.0
+        version: 2.81.1
+      '@fluidframework/sequence':
+        specifier: ~2.81.0
+        version: 2.81.1
+      '@fluidframework/shared-object-base':
+        specifier: ~2.81.0
+        version: 2.81.1
+      '@tylerbu/levee-client':
+        specifier: workspace:^
+        version: link:../levee-client
+      fluid-framework:
+        specifier: ~2.81.0
+        version: 2.81.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.3.8
+        version: 2.3.8
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.58.2
+      '@types/node':
+        specifier: ^20.19.25
+        version: 20.19.33
+      '@types/react':
+        specifier: ^18.3.18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.2
+        version: 4.7.0(vite@7.3.1(@types/node@20.19.33)(yaml@2.8.2))
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.2
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.1(@types/node@20.19.33)(yaml@2.8.2)
+
 packages:
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
@@ -703,6 +761,9 @@ packages:
 
   '@fluidframework/protocol-definitions@4.0.0':
     resolution: {integrity: sha512-pdMxMPld/oXgEbyERZGciVGchy4ZGcxypqVlDpBaljqwUW48eHaUkQ/+g9zcvmOxARVe8hLSK/pAH2n0lSZp9Q==}
+
+  '@fluidframework/react@2.81.1':
+    resolution: {integrity: sha512-/5offztct092ACEVETLMA7Xykki5SR+Qa+2YfcNrNw4C2RCdJxpw+YhevWsCenUGkPYRnpvTQ9yiqoqIq3Qy+g==}
 
   '@fluidframework/request-handler@2.81.1':
     resolution: {integrity: sha512-XrPv7MBZxHF159oaxx9yhaeEmcqA7ELllKWQqdzKg7+4Nz652NlW+S8spjxctMr1q7kqo70/LRc8hpgW1QXfRw==}
@@ -3607,6 +3668,19 @@ snapshots:
   '@fluidframework/protocol-definitions@3.2.0': {}
 
   '@fluidframework/protocol-definitions@4.0.0': {}
+
+  '@fluidframework/react@2.81.1':
+    dependencies:
+      '@fluidframework/aqueduct': 2.81.1
+      '@fluidframework/core-interfaces': 2.81.1
+      '@fluidframework/datastore-definitions': 2.81.1
+      '@fluidframework/fluid-static': 2.81.1
+      '@fluidframework/runtime-definitions': 2.81.1
+      '@fluidframework/shared-object-base': 2.81.1
+      '@fluidframework/tree': 2.81.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/request-handler@2.81.1':
     dependencies:

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,6 +17,9 @@
 		},
 		{
 			"path": "./packages/levee-presence-tracker"
+		},
+		{
+			"path": "./packages/levee-todo-list"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Adds `levee-todo-list` example app: a collaborative todo list built with Fluid Framework's SharedTree, including React UI with add/delete/toggle/edit and real-time sync via Levee
- Adds Playwright e2e tests for the todo-list (collaborative editing, conflict resolution, persistence)
- Adds disconnect/rejoin e2e tests to `levee-presence-tracker`
- Registers `levee-todo-list` in the client workspace and project references