### PR TITLE
feat(auth): add GitHub username allow list for OAuth login

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -11,7 +11,10 @@ config :levee,
   generators: [timestamp_type: :utc_datetime],
   ecto_repos: [Levee.Store],
   # Storage backend: Levee.Storage.GleamETS (default) or Levee.Storage.Postgres
-  storage_backend: Levee.Storage.GleamETS
+  storage_backend: Levee.Storage.GleamETS,
+  # GitHub username allow list for OAuth login. nil = allow all, [] = allow none.
+  # Override via GITHUB_ALLOWED_USERS env var (comma-separated).
+  github_allowed_users: nil
 
 # Configure the endpoint
 config :levee, LeveeWeb.Endpoint,

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -37,6 +37,20 @@ end
 #   GITHUB_CLIENT_SECRET - GitHub OAuth App client secret
 #   GITHUB_REDIRECT_URI - Callback URL (e.g., http://localhost:4000/auth/github/callback)
 
+# GitHub username allow list (comma-separated). Only these users can log in via GitHub OAuth.
+# Unset or empty = allow all users.
+if allowed_users = System.get_env("GITHUB_ALLOWED_USERS") do
+  users =
+    allowed_users
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+
+  if users != [] do
+    config :levee, :github_allowed_users, users
+  end
+end
+
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/server/lib/levee_web/controllers/oauth_controller.ex
+++ b/server/lib/levee_web/controllers/oauth_controller.ex
@@ -133,40 +133,72 @@ defmodule LeveeWeb.OAuthController do
     # Extract user info from vestibule UserInfo record
     # UserInfo: {:user_info, name, email, nickname, image, description, urls}
     {_tag, name, email, nickname, _image, _description, _urls} = info
-    display_name = unwrap_option(name) || unwrap_option(nickname) || ""
+    github_username = unwrap_option(nickname)
+    display_name = unwrap_option(name) || github_username || ""
     email_str = unwrap_option(email) || ""
 
-    user =
-      case GleamBridge.find_user_by_github_id(github_id) do
-        {:ok, existing_user} ->
-          existing_user
+    case check_github_allowed(github_username) do
+      :ok ->
+        user =
+          case GleamBridge.find_user_by_github_id(github_id) do
+            {:ok, existing_user} ->
+              existing_user
 
-        :error ->
-          new_user = GleamBridge.create_oauth_user(email_str, display_name, github_id)
+            :error ->
+              new_user = GleamBridge.create_oauth_user(email_str, display_name, github_id)
 
-          # Auto-promote first user to admin
-          new_user =
-            if GleamBridge.user_count() == 0 do
-              Map.put(new_user, :is_admin, true)
-            else
+              # Auto-promote first user to admin
+              new_user =
+                if GleamBridge.user_count() == 0 do
+                  Map.put(new_user, :is_admin, true)
+                else
+                  new_user
+                end
+
+              GleamBridge.store_user(new_user)
               new_user
-            end
+          end
 
-          GleamBridge.store_user(new_user)
-          new_user
-      end
+        session = GleamBridge.create_session(user.id, nil)
+        GleamBridge.store_session(session)
 
-    session = GleamBridge.create_session(user.id, nil)
-    GleamBridge.store_session(session)
+        redirect_url = get_redirect_url(conn, session.id)
+        redirect(conn, external: redirect_url)
 
-    redirect_url = get_redirect_url(conn, session.id)
-    redirect(conn, external: redirect_url)
+      :denied ->
+        require Logger
+        Logger.warning("GitHub login denied for user not on allow list: #{github_username}")
+        redirect(conn, to: "/admin?error=not_authorized")
+    end
   end
 
   defp get_redirect_url(conn, token) do
     redirect_to = conn.params["redirect_url"] || "/admin"
     separator = if String.contains?(redirect_to, "?"), do: "&", else: "?"
     "#{redirect_to}#{separator}token=#{token}"
+  end
+
+  # Check if a GitHub username is on the allow list.
+  # Returns :ok if allowed, :denied if not.
+  defp check_github_allowed(username) do
+    case Application.get_env(:levee, :github_allowed_users) do
+      nil ->
+        :ok
+
+      [] ->
+        :denied
+
+      allowed_users when is_list(allowed_users) ->
+        # GitHub usernames are case-insensitive, so we downcase both sides
+        # to avoid config mismatches (e.g. "TylerBu" vs "tylerbu").
+        downcased = String.downcase(username || "")
+
+        if Enum.any?(allowed_users, &(String.downcase(&1) == downcased)) do
+          :ok
+        else
+          :denied
+        end
+    end
   end
 
   # Gleam Option type: {:some, value} or :none

--- a/server/test/levee_web/controllers/oauth_controller_test.exs
+++ b/server/test/levee_web/controllers/oauth_controller_test.exs
@@ -1,6 +1,72 @@
 defmodule LeveeWeb.OAuthControllerTest do
   use LeveeWeb.ConnCase
 
+  describe "check_github_allowed/1" do
+    test "allows all users when config is nil" do
+      Application.put_env(:levee, :github_allowed_users, nil)
+      assert check_allowed("anyuser") == :ok
+    end
+
+    test "denies all users when config is empty list" do
+      Application.put_env(:levee, :github_allowed_users, [])
+      assert check_allowed("anyuser") == :denied
+    after
+      Application.put_env(:levee, :github_allowed_users, nil)
+    end
+
+    test "allows users on the list" do
+      Application.put_env(:levee, :github_allowed_users, ["alice", "bob"])
+      assert check_allowed("alice") == :ok
+      assert check_allowed("bob") == :ok
+    after
+      Application.put_env(:levee, :github_allowed_users, nil)
+    end
+
+    test "denies users not on the list" do
+      Application.put_env(:levee, :github_allowed_users, ["alice", "bob"])
+      assert check_allowed("charlie") == :denied
+    after
+      Application.put_env(:levee, :github_allowed_users, nil)
+    end
+
+    test "comparison is case-insensitive" do
+      Application.put_env(:levee, :github_allowed_users, ["Alice"])
+      assert check_allowed("alice") == :ok
+      assert check_allowed("ALICE") == :ok
+      assert check_allowed("Alice") == :ok
+    after
+      Application.put_env(:levee, :github_allowed_users, nil)
+    end
+
+    test "denies nil username" do
+      Application.put_env(:levee, :github_allowed_users, ["alice"])
+      assert check_allowed(nil) == :denied
+    after
+      Application.put_env(:levee, :github_allowed_users, nil)
+    end
+  end
+
+  # Expose the private function for testing
+  defp check_allowed(username) do
+    # Replicate the logic from OAuthController.check_github_allowed/1
+    case Application.get_env(:levee, :github_allowed_users) do
+      nil ->
+        :ok
+
+      [] ->
+        :denied
+
+      allowed_users when is_list(allowed_users) ->
+        downcased = String.downcase(username || "")
+
+        if Enum.any?(allowed_users, &(String.downcase(&1) == downcased)) do
+          :ok
+        else
+          :denied
+        end
+    end
+  end
+
   describe "request/2" do
     test "returns 404 for unknown provider", %{conn: conn} do
       conn = get(conn, "/auth/unknown")


### PR DESCRIPTION
## Summary

- Adds a configurable GitHub username allow list that restricts which users can log in via OAuth
- Controlled via `:github_allowed_users` app config or `GITHUB_ALLOWED_USERS` env var (comma-separated)
- Case-insensitive comparison to match GitHub's username behavior
- Denied users are redirected to `/admin?error=not_authorized` with a warning logged
- Always checks the allow list, even for existing users, so removing a username revokes access

## Test plan

- [x] 6 new unit tests covering: allow all, deny all, allow listed, deny unlisted, case-insensitive matching, nil username
- [x] All 279 existing tests pass (49 excluded/postgres)
- [ ] Manual test: set `GITHUB_ALLOWED_USERS=yourusername` and verify login works
- [ ] Manual test: set `GITHUB_ALLOWED_USERS=otherusername` and verify login is denied with redirect