### PR TITLE
fix(ci): use tab indentation in jq version bump output

### DIFF
--- a/.github/workflows/client-changie-release.yml
+++ b/.github/workflows/client-changie-release.yml
@@ -37,7 +37,7 @@ jobs:
           SEMVER="${VERSION#v}"
 
           for pkg in client/packages/levee-driver client/packages/levee-client client/packages/levee-example client/packages/levee-presence-tracker; do
-            jq --arg v "$SEMVER" '.version = $v' "$pkg/package.json" > "$pkg/package.json.tmp"
+            jq --tab --arg v "$SEMVER" '.version = $v' "$pkg/package.json" > "$pkg/package.json.tmp"
             mv "$pkg/package.json.tmp" "$pkg/package.json"
           done
 


### PR DESCRIPTION
The client release workflow uses `jq` to bump `package.json` versions, but `jq` defaults to 2-space indentation while Biome requires tabs. This causes the Client Lint CI check to fail on release PRs (e.g. #43).

Adds the `--tab` flag to the `jq` command in `client-changie-release.yml`.