### PR TITLE
fix: update shelf to latest main (e92d136)

### DIFF
--- a/docs/adr/001-ets-public-access.md
+++ b/docs/adr/001-ets-public-access.md
@@ -1,0 +1,76 @@
+# ADR-001: Public ETS access for levee_storage tables
+
+- **Status:** Accepted
+- **Date:** 2026-04-11
+- **Context:** Shelf dependency update from 3a756bf to e92d136
+
+## Context
+
+Levee uses [shelf](https://github.com/tylerbutler/shelf) for persistent ETS/DETS storage. The `levee_storage` module opens shelf tables in a GenServer's `init/1` and stores the handles in `persistent_term` so that any process (Phoenix controllers, WebSocket channels, the Session GenServer) can read and write directly without routing through the owning GenServer.
+
+Shelf changed its ETS table creation from `public` to `protected` access mode. In Erlang, `protected` means only the process that created the table can write; any process can read. This broke levee's cross-process write pattern — all writes returned `NotOwner` errors.
+
+### levee_auth (not affected by this decision)
+
+The `session_store` already follows shelf's intended pattern: a Gleam actor owns the tables and serializes all reads and writes through its message handler. The fix was to move `init_tables` into the actor's initializer so the actor process (not the Elixir supervisor) is the ETS owner. No access mode workaround needed.
+
+### levee_storage (this decision)
+
+The storage layer's tables are accessed from many processes. Routing all writes through a single GenServer would serialize all storage operations, adding latency and creating a throughput bottleneck for a real-time collaboration server.
+
+## Decision
+
+After opening shelf tables in `levee_storage/ets.gleam`, replace each `protected` ETS table with a `public` clone via an Erlang FFI helper (`make_table_public/1`). This restores the pre-upgrade behavior where any process can read and write.
+
+### Why this is acceptable
+
+Per-document write serialization is already enforced at a higher layer. Each document has a dedicated `Levee.Documents.Session` GenServer that processes all client operations sequentially. The request flow is:
+
+```
+Client → WebSocket Channel → Session GenServer → Storage (ETS write)
+```
+
+The Session GenServer is the single writer for a given document's data. Concurrent writes to *different* documents touch different ETS keys and don't conflict (ETS guarantees atomicity of individual operations).
+
+### Known risks
+
+1. **Read-modify-write races.** Functions like `update_document_sequence` and `update_ref` do `lookup` then `insert` without locking. If two processes call these for the same key concurrently, last-write-wins. This is safe today because the Session GenServer serializes per-document mutations, but would become a bug if a new code path writes to storage outside the Session.
+
+2. **Fragile FFI.** The `make_table_public` helper reaches into shelf's opaque `PSet` tuple to extract the ETS reference (element 2). This breaks if shelf changes its internal representation. Tracked in [shelf#49](https://github.com/tylerbutler/shelf/issues/49) — if shelf adds a configurable access mode, this workaround can be removed.
+
+3. **Save/close ownership.** Shelf's `save` and `close` operations are also owner-only. These are called from the `GleamETS` GenServer (which is the ETS owner), so they work correctly. If save/close were ever called from another process, they would fail.
+
+## Alternatives considered
+
+### Route all writes through the GenServer
+
+The architecturally "correct" approach per shelf's design. Every storage mutation would become a `GenServer.call`, serializing all writes through one process.
+
+**Rejected because:**
+- Adds ~50-100μs per operation (message send + receive + scheduling)
+- Serializes ALL writes (across all documents and tenants) through one process, creating a bottleneck
+- The real concurrency protection already exists at the Session layer
+- Would require significant refactoring of the storage module and all callers
+
+### Transfer table ownership per-write
+
+Use `ets:give_away/3` to transfer ownership to the writing process, then transfer back.
+
+**Rejected because:**
+- Impractical — ownership transfer requires cooperation from both processes
+- Would serialize worse than the GenServer approach
+
+### Wait for shelf to add access mode config
+
+Do nothing and wait for [shelf#49](https://github.com/tylerbutler/shelf/issues/49).
+
+**Rejected because:**
+- Blocks the shelf upgrade on an upstream change with no timeline
+- The FFI workaround is small and contained
+
+## Consequences
+
+- Storage writes from any process continue to work as before the shelf upgrade.
+- A comment in `levee_storage/ets.gleam` documents the assumption that per-document writes are serialized by the Session GenServer.
+- If a new code path needs to write to storage outside the Session GenServer, it must either serialize writes through its own process or this decision must be revisited.
+- When shelf ships a configurable access mode ([shelf#49](https://github.com/tylerbutler/shelf/issues/49)), the `make_table_public` FFI workaround should be replaced with the native config option.

--- a/server/levee_auth/gleam.toml
+++ b/server/levee_auth/gleam.toml
@@ -11,7 +11,7 @@ gleam_time = ">= 1.0.0 and < 2.0.0"
 gleam_otp = ">= 0.14.0 and < 2.0.0"
 gleam_erlang = ">= 0.34.0 and < 2.0.0"
 youid = ">= 1.0.0 and < 2.0.0"
-shelf = { git = "https://github.com/tylerbutler/shelf", ref = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" }
+shelf = { git = "https://github.com/tylerbutler/shelf", ref = "e92d136bf6296498d31fe0856570ba97d012cbd0" }
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/server/levee_auth/manifest.toml
+++ b/server/levee_auth/manifest.toml
@@ -9,7 +9,7 @@ packages = [
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
-  { name = "shelf", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/shelf", commit = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" },
+  { name = "shelf", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/shelf", commit = "e92d136bf6296498d31fe0856570ba97d012cbd0" },
   { name = "youid", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_stdlib", "gleam_time"], otp_app = "youid", source = "hex", outer_checksum = "580E909FD704DB16416D5CB080618EDC2DA0F1BE4D21B490C0683335E3FFC5AF" },
 ]
 
@@ -21,5 +21,5 @@ gleam_otp = { version = ">= 0.14.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 1.0.0" }
 gleam_time = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-shelf = { git = "https://github.com/tylerbutler/shelf", ref = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" }
+shelf = { git = "https://github.com/tylerbutler/shelf", ref = "e92d136bf6296498d31fe0856570ba97d012cbd0" }
 youid = { version = ">= 1.0.0 and < 2.0.0" }

--- a/server/levee_auth/src/session_store.gleam
+++ b/server/levee_auth/src/session_store.gleam
@@ -3,6 +3,7 @@
 //// Uses shelf/set (ETS + DETS) for typed, persistent key-value storage.
 //// Data is persisted to DETS files on disk and survives restarts.
 
+import gleam/dynamic/decode
 import gleam/erlang/process.{type Subject}
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -53,26 +54,47 @@ pub type Tables {
   )
 }
 
-fn dets_path(data_dir: String, table_name: String) -> String {
-  data_dir <> "/" <> table_name <> ".dets"
-}
-
 /// Open all persistent tables. Call once at startup.
 pub fn init_tables(data_dir: String) -> Tables {
   let assert Ok(users) =
-    set.open(name: "levee_auth_users", path: dets_path(data_dir, "auth_users"))
+    set.open(
+      name: "levee_auth_users",
+      path: "auth_users.dets",
+      base_directory: data_dir,
+      key: decode.string,
+      value: trusted_decoder(),
+    )
   let assert Ok(sessions) =
     set.open(
       name: "levee_auth_sessions",
-      path: dets_path(data_dir, "auth_sessions"),
+      path: "auth_sessions.dets",
+      base_directory: data_dir,
+      key: decode.string,
+      value: trusted_decoder(),
     )
   let assert Ok(memberships) =
     set.open(
       name: "levee_auth_memberships",
-      path: dets_path(data_dir, "auth_memberships"),
+      path: "auth_memberships.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
     )
   Tables(users:, sessions:, memberships:)
 }
+
+fn trusted_decoder() -> decode.Decoder(a) {
+  decode.dynamic |> decode.map(coerce)
+}
+
+fn string_pair_key() -> decode.Decoder(#(String, String)) {
+  use a <- decode.field(0, decode.string)
+  use b <- decode.field(1, decode.string)
+  decode.success(#(a, b))
+}
+
+@external(erlang, "gleam_stdlib", "identity")
+fn coerce(value: a) -> b
 
 /// Close all tables, persisting data to disk.
 pub fn close_tables(tables: Tables) -> Nil {
@@ -87,10 +109,11 @@ pub fn close_tables(tables: Tables) -> Nil {
 // ---------------------------------------------------------------------------
 
 /// Start the session store actor with persistent shelf tables.
+/// Tables are opened inside the actor process so it becomes the ETS owner,
+/// which is required by shelf's protected table access model.
 pub fn start(data_dir: String) -> Result(Subject(Message), actor.StartError) {
-  let tables = init_tables(data_dir)
-
   actor.new_with_initialiser(5000, fn(subject) {
+    let tables = init_tables(data_dir)
     actor.initialised(tables)
     |> actor.returning(subject)
     |> Ok

--- a/server/levee_storage/gleam.toml
+++ b/server/levee_storage/gleam.toml
@@ -8,7 +8,7 @@ gleam_stdlib = ">= 0.62.0 and < 2.0.0"
 gleam_json = ">= 3.0.0 and < 4.0.0"
 gleam_crypto = ">= 1.3.0 and < 2.0.0"
 gleam_erlang = ">= 0.34.0 and < 2.0.0"
-shelf = { git = "https://github.com/tylerbutler/shelf", ref = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" }
+shelf = { git = "https://github.com/tylerbutler/shelf", ref = "e92d136bf6296498d31fe0856570ba97d012cbd0" }
 pog = ">= 4.0.0 and < 5.0.0"
 gleam_otp = ">= 1.2.0 and < 2.0.0"
 

--- a/server/levee_storage/manifest.toml
+++ b/server/levee_storage/manifest.toml
@@ -23,7 +23,7 @@ packages = [
   { name = "pg_types", version = "0.6.0", build_tools = ["rebar3"], requirements = [], otp_app = "pg_types", source = "hex", outer_checksum = "9949A4849DD13408FA249AB7B745E0D2DFDB9532AEE2B9722326E33CD082A778" },
   { name = "pgo", version = "0.20.0", build_tools = ["rebar3"], requirements = ["backoff", "opentelemetry_api", "pg_types"], otp_app = "pgo", source = "hex", outer_checksum = "2F11E6649CEB38E569EF56B16BE1D04874AE5B11A02867080A2817CE423C683B" },
   { name = "pog", version = "4.1.0", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_otp", "gleam_stdlib", "gleam_time", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "E4AFBA39A5FAA2E77291836C9683ADE882E65A06AB28CA7D61AE7A3AD61EBBD5" },
-  { name = "shelf", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/shelf", commit = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" },
+  { name = "shelf", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "https://github.com/tylerbutler/shelf", commit = "e92d136bf6296498d31fe0856570ba97d012cbd0" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
@@ -37,5 +37,5 @@ gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.62.0 and < 2.0.0" }
 pog = { version = ">= 4.0.0 and < 5.0.0" }
-shelf = { git = "https://github.com/tylerbutler/shelf", ref = "3a756bfca128b8f05f43ff7b4e85bac454e207dd" }
+shelf = { git = "https://github.com/tylerbutler/shelf", ref = "e92d136bf6296498d31fe0856570ba97d012cbd0" }
 startest = { version = "~> 0.8" }

--- a/server/levee_storage/src/levee_storage/ets.gleam
+++ b/server/levee_storage/src/levee_storage/ets.gleam
@@ -6,10 +6,24 @@
 ////
 //// Deltas and summaries use USet (no ordered set in DETS) with
 //// sort-on-read for ordered queries.
+////
+//// ## ETS access mode
+////
+//// Shelf creates `protected` ETS tables (owner-only writes), but this
+//// module's tables are shared via `persistent_term` and written to from
+//// any process (controllers, channels, etc.). We swap each table to
+//// `public` access after opening — see `make_public` and ADR-001.
+////
+//// This is safe because per-document writes are serialized through the
+//// Session GenServer (`Levee.Documents.Session`). If a new code path
+//// writes to storage outside the Session GenServer, it must either
+//// serialize through its own process or use shelf's protected mode.
+//// See: docs/adr/001-ets-public-access.md
 
 import gleam/bit_array
 import gleam/crypto
 import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
 import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -44,21 +58,93 @@ pub type Tables {
 /// The data_dir is the directory where DETS files will be stored.
 pub fn init(data_dir: String) -> Tables {
   let assert Ok(documents) =
-    set.open(name: "levee_documents", path: dets_path(data_dir, "documents"))
+    set.open(
+      name: "levee_documents",
+      path: "documents.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(deltas) =
-    set.open(name: "levee_deltas", path: dets_path(data_dir, "deltas"))
+    set.open(
+      name: "levee_deltas",
+      path: "deltas.dets",
+      base_directory: data_dir,
+      key: string_string_int_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(blobs) =
-    set.open(name: "levee_blobs", path: dets_path(data_dir, "blobs"))
+    set.open(
+      name: "levee_blobs",
+      path: "blobs.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(trees) =
-    set.open(name: "levee_trees", path: dets_path(data_dir, "trees"))
+    set.open(
+      name: "levee_trees",
+      path: "trees.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(commits) =
-    set.open(name: "levee_commits", path: dets_path(data_dir, "commits"))
+    set.open(
+      name: "levee_commits",
+      path: "commits.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(refs) =
-    set.open(name: "levee_refs", path: dets_path(data_dir, "refs"))
+    set.open(
+      name: "levee_refs",
+      path: "refs.dets",
+      base_directory: data_dir,
+      key: string_pair_key(),
+      value: trusted_decoder(),
+    )
   let assert Ok(summaries) =
-    set.open(name: "levee_summaries", path: dets_path(data_dir, "summaries"))
+    set.open(
+      name: "levee_summaries",
+      path: "summaries.dets",
+      base_directory: data_dir,
+      key: string_string_int_key(),
+      value: trusted_decoder(),
+    )
+
+  // Shelf creates protected ETS tables (owner-only writes), but levee
+  // shares table handles via persistent_term for cross-process access.
+  let documents = make_public(documents)
+  let deltas = make_public(deltas)
+  let blobs = make_public(blobs)
+  let trees = make_public(trees)
+  let commits = make_public(commits)
+  let refs = make_public(refs)
+  let summaries = make_public(summaries)
 
   Tables(documents:, deltas:, blobs:, trees:, commits:, refs:, summaries:)
+}
+
+@external(erlang, "storage_ffi_helpers", "make_table_public")
+fn make_public(table: PSet(k, v)) -> PSet(k, v)
+
+fn trusted_decoder() -> decode.Decoder(a) {
+  decode.dynamic |> decode.map(coerce)
+}
+
+fn string_pair_key() -> decode.Decoder(#(String, String)) {
+  use a <- decode.field(0, decode.string)
+  use b <- decode.field(1, decode.string)
+  decode.success(#(a, b))
+}
+
+fn string_string_int_key() -> decode.Decoder(#(String, String, Int)) {
+  use a <- decode.field(0, decode.string)
+  use b <- decode.field(1, decode.string)
+  use c <- decode.field(2, decode.int)
+  decode.success(#(a, b, c))
 }
 
 /// Close all tables, persisting data to disk.
@@ -83,10 +169,6 @@ pub fn save(tables: Tables) -> Nil {
   let _ = set.save(tables.refs)
   let _ = set.save(tables.summaries)
   Nil
-}
-
-fn dets_path(data_dir: String, table_name: String) -> String {
-  data_dir <> "/" <> table_name <> ".dets"
 }
 
 // ---------------------------------------------------------------------------

--- a/server/levee_storage/src/storage_ffi_helpers.erl
+++ b/server/levee_storage/src/storage_ffi_helpers.erl
@@ -3,7 +3,7 @@
 
 -export([identity/1, make_summary_meta/2, json_from_map/1,
          dynamic_to_json_string/1, json_string_to_dynamic/1,
-         pg_timestamp_to_datetime/1]).
+         pg_timestamp_to_datetime/1, make_table_public/1]).
 
 %% @doc Identity function for type coercion.
 identity(X) -> X.
@@ -46,3 +46,15 @@ pg_timestamp_to_datetime({{Year, Month, Day}, {Hour, Min, Sec}}) ->
 pg_timestamp_to_datetime(Other) ->
     %% Already a DateTime or something else, pass through
     Other.
+
+%% @doc Replace a shelf PSet's protected ETS table with a public one.
+%% Shelf creates protected tables (owner-only writes), but levee
+%% stores the table handle in persistent_term and writes from any process.
+%% Must be called from the table owner process (e.g., during GenServer init).
+make_table_public(PSet) ->
+    OldEts = element(2, PSet),
+    Type = proplists:get_value(type, ets:info(OldEts)),
+    NewEts = ets:new(shelf_ets, [Type, public, {keypos, 1}, {read_concurrency, true}]),
+    ets:foldl(fun(Entry, _) -> ets:insert(NewEts, Entry) end, ok, OldEts),
+    ets:delete(OldEts),
+    setelement(2, PSet, NewEts).


### PR DESCRIPTION
## Summary

- Update shelf dependency from `3a756bf` to `e92d136` (latest main) in both `levee_auth` and `levee_storage`
- Adapt to shelf's new `set.open` API (now requires `base_directory`, key/value decoders)
- Handle shelf's switch from `public` to `protected` ETS tables:
  - **levee_auth**: Move `init_tables` into the actor initializer so the actor process owns the tables (clean fix, no workaround needed)
  - **levee_storage**: Swap each protected table for a public clone via FFI, since tables are shared via `persistent_term` and written from many processes
- Add ADR-001 documenting the levee_storage access mode decision and its risks
- Filed tylerbutler/shelf#49 requesting a configurable access mode to eventually replace the FFI workaround

## Test plan

- [x] All Gleam tests pass (levee_protocol, levee_auth, levee_oauth, levee_admin)
- [x] All Elixir tests pass (297 tests, 0 failures)
- [x] Tests pass on repeated runs (DETS persistence doesn't break subsequent runs)